### PR TITLE
bazel_skylib default branch was renamed.

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -38,8 +38,8 @@ http_archive(
 # Dependencies.
 http_archive(
     name = "bazel_skylib",
-    strip_prefix = "bazel-skylib-master",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/master.zip"],
+    strip_prefix = "bazel-skylib-main",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/main.zip"],
 )
 
 # Protocol buffer library itself.


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel-skylib/branches and https://github.com/bazelbuild/bazel-skylib/issues/293.

Fixes https://github.com/google/eidos-audition/issues/1